### PR TITLE
Use 'video game' phrasing in alt text

### DIFF
--- a/themes/carlosgm/layouts/partials/footer.html
+++ b/themes/carlosgm/layouts/partials/footer.html
@@ -2,7 +2,7 @@
   {{ $image := resources.Get "images/carlosgm-bg1216.png" }}
   <img
     src="{{ $image.Permalink }}"
-    alt="A drawing of Carlos holding a sword and a shield inspired on the videogame Zelda" />
+    alt="A drawing of Carlos holding a sword and a shield inspired on the video game Zelda" />
   <div class="text-right">
     <div>
       Art by the amazing

--- a/themes/carlosgm/layouts/partials/header.html
+++ b/themes/carlosgm/layouts/partials/header.html
@@ -11,7 +11,7 @@
       {{ $image := $image.Process "fit 220x80" }}
       <img
         src="{{ $image.Permalink }}"
-        alt="A drawing of Carlos holding a sword and a shield inspired on the videogame Zelda" />
+        alt="A drawing of Carlos holding a sword and a shield inspired on the video game Zelda" />
     </div>
   </div>
   <!-- LanguageSwitch /-->


### PR DESCRIPTION
## Summary
- Replace "videogame" with "video game" in header image alt text
- Replace "videogame" with "video game" in footer image alt text

## Testing
- `npm run lint:prettier` *(fails: Code style issues found in assets/css/output.css)*

------
https://chatgpt.com/codex/tasks/task_e_6899b79523508325971bf11e940c9d82