### PR TITLE
Remove passHref from header link

### DIFF
--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -26,7 +26,7 @@
         <header
   class="border-t-8 border-x-8 border-black-top px-8 pt-6 flex justify-between">
   <div>
-    <a href="/" passHref>
+    <a href="/">
       <h1 class="inline-block align-top pt-4">
         Carlos<span class="text-red-gm">GM</span>
       </h1>

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
         <header
   class="border-t-8 border-x-8 border-black-top px-8 pt-6 flex justify-between">
   <div>
-    <a href="/" passHref>
+    <a href="/">
       <h1 class="inline-block align-top pt-4">
         Carlos<span class="text-red-gm">GM</span>
       </h1>

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -26,7 +26,7 @@
         <header
   class="border-t-8 border-x-8 border-black-top px-8 pt-6 flex justify-between">
   <div>
-    <a href="/" passHref>
+    <a href="/">
       <h1 class="inline-block align-top pt-4">
         Carlos<span class="text-red-gm">GM</span>
       </h1>

--- a/themes/carlosgm/layouts/partials/header.html
+++ b/themes/carlosgm/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header
   class="border-t-8 border-x-8 border-black-top px-8 pt-6 flex justify-between">
   <div>
-    <a href="/" passHref>
+    <a href="/">
       <h1 class="inline-block align-top pt-4">
         Carlos<span class="text-red-gm">GM</span>
       </h1>


### PR DESCRIPTION
## Summary
- drop unused `passHref` attribute from header links
- regenerate static pages to ensure links rely solely on `href`

## Testing
- `npm run lint:prettier` *(fails: assets/css/output.css not formatted)*


------
https://chatgpt.com/codex/tasks/task_e_6899bba7776c832586bf83e59b192e17